### PR TITLE
Properly compare PHP's shorthand byte values

### DIFF
--- a/administrator/components/com_jce/install.php
+++ b/administrator/components/com_jce/install.php
@@ -15,7 +15,25 @@ defined('_JEXEC') or die('RESTRICTED');
 @set_time_limit(0);
 
 // try to increase memory limit
-if ((int) ini_get('memory_limit') < 32) {
+$memoryInBytes = function ($value) {
+     $value = trim($value);
+     $multipliers = array(
+        'g' => 1024 * 1024 * 1024,
+        'm' => 1024 * 1024,
+        'k' => 1024
+     );
+
+     $unit  = strtolower(substr($value, -1, 1));
+
+     if (!array_key_exists($unit, $multipliers)) {
+        return $value;
+     }
+
+     return ((int)$value * $multipliers[$unit]);
+};
+
+$memoryLimit = trim(ini_get('memory_limit'));
+if ($memoryLimit != -1 && $memoryInBytes($memoryLimit) < 32 * 1024 * 1024) {
     @ini_set('memory_limit', '32M');
 }
 


### PR DESCRIPTION
The current logic assumes that memory_limit is always described in Megabytes. However, if the memory_limit is expressed in Gigabytes for example, the script will think it's less than 32 Megabytes and lower the memory limit. 

This happened to me while testing joomlatools/joomla-composer#16. PHP's memory_limit was set to 1G but JCE installation lowered it to 32M :)
