### PR TITLE
Bug in the avoid processing twice

### DIFF
--- a/plugins/system/jce/jce.php
+++ b/plugins/system/jce/jce.php
@@ -97,6 +97,7 @@ class PlgSystemJce extends JPlugin {
 
         foreach ($fields as $field) {
             
+            $name   = $field->getAttribute('name');
             // avoid processing twice
             if (strpos($form->getFieldAttribute($name, 'class'), 'wf-media-input') !== false) {
                 return;
@@ -116,7 +117,6 @@ class PlgSystemJce extends JPlugin {
                   continue;
                 }
 
-                $name   = $field->getAttribute('name');
                 $group  = (string) $field->group;
                 $form->setFieldAttribute($name, 'link', $link, $group);
                 $form->setFieldAttribute($name, 'class', 'input-large wf-media-input', $group);


### PR DESCRIPTION
You have bug in the 'avoid processing twice' if. You want to check if field has class 'wf-media-input' but previously you should fill $name variable. Because right now this condition is true for every field except first media field. And if you have more than one media field, it works only for first media field.
