### PR TITLE
Add to 'textarea.wfNoEditor' class 'box-sizing: border-box'

### DIFF
--- a/components/com_jce/editor/libraries/css/editor.css
+++ b/components/com_jce/editor/libraries/css/editor.css
@@ -33,6 +33,7 @@ textarea.wfEditor, textarea.wfNoEditor {
     line-height: 16px;
     position: relative;
     border: 1px solid #CCCCCC;
+    box-sizing: border-box;    
 }
 textarea.wfEditor:focus, textarea.wfNoEditor:focus {
     background: #FFFFFF none;


### PR DESCRIPTION
Add to ```textarea.wfNoEditor``` class the attribute ```box-sizing: border-box``` since when editor is toggled off the textarea has wrong width.